### PR TITLE
Bulk job attributes

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -260,13 +260,16 @@ export class Instrumentation extends InstrumentationBase {
     return function addBulk(original) {
       return async function patch(
         this: FlowProducer,
-        ...args
+        ...args: [FlowJob[], ...any]
       ): Promise<JobNode> {
         const spanName = `${action}`;
+        const names = args[0].map((job) => job.name);
         const span = tracer.startSpan(spanName, {
           attributes: {
             [SemanticAttributes.MESSAGING_SYSTEM]:
               BullMQAttributes.MESSAGING_SYSTEM,
+            [BullMQAttributes.JOB_BULK_NAMES]: names,
+            [BullMQAttributes.JOB_BULK_COUNT]: names.length,
           },
           kind: SpanKind.INTERNAL,
         });

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -200,9 +200,9 @@ export class Instrumentation extends InstrumentationBase {
     return function addBulk(original) {
       return async function patch(
         this: bullmq.Queue,
-        ...args: bullmq.Job[]
+        ...args: [bullmq.Job[], ...any]
       ): Promise<bullmq.Job[]> {
-        const names = args.map((job) => job.name);
+        const names = args[0].map((job) => job.name);
 
         const spanName = `${this.name} ${action}`;
         const span = tracer.startSpan(spanName, {

--- a/test/instrumentation.test.ts
+++ b/test/instrumentation.test.ts
@@ -372,9 +372,8 @@ describe("bullmq", () => {
       );
       assert.notStrictEqual(flowProducerAddBulkSpan, undefined);
       assertContains(flowProducerAddBulkSpan?.attributes!, {
-        // TODO: bulk.count and bulk.names should be present?
-        // 'messaging.bullmq.job.bulk.names': ["jobName1", "jobName2"],
-        // 'messaging.bullmq.job.bulk.count': 2,
+        "messaging.bullmq.job.bulk.names": ["jobName1", "jobName2"],
+        "messaging.bullmq.job.bulk.count": 2,
       });
       assertDoesNotContain(flowProducerAddBulkSpan?.attributes!, [
         "messaging.destination",

--- a/test/instrumentation.test.ts
+++ b/test/instrumentation.test.ts
@@ -208,11 +208,8 @@ describe("bullmq", () => {
       assert.notStrictEqual(queueAddBulkSpan, undefined);
       assertContains(queueAddBulkSpan?.attributes!, {
         "messaging.destination": "queueName",
-        // TODO: fix these values
-        // 'messaging.bullmq.job.bulk.names': ["jobName1", "jobName2"],
-        "messaging.bullmq.job.bulk.names": [undefined],
-        // 'messaging.bullmq.job.bulk.count': 2,
-        "messaging.bullmq.job.bulk.count": 1,
+        "messaging.bullmq.job.bulk.names": ["jobName1", "jobName2"],
+        "messaging.bullmq.job.bulk.count": 2,
       });
       assertDoesNotContain(queueAddBulkSpan?.attributes!, [
         "messaging.bullmq.job.name",


### PR DESCRIPTION
A nice short PR to begin to familiarise ourselves with the instrumentation.

### [Fix bulk job attributes bug](https://github.com/appsignal/opentelemetry-instrumentation-bullmq/commit/02cff3cb9675a7bccf748e50e713039ff55994fe)

The `Queue.addBulk` method has `.bulk.names` and `.bulk.count`
attributes, but due to a bug in the implementation, their values
are always `[undefined]` and `1`. This commit fixes this so that
their values contain the list of names of jobs enqueued and its
count.

### [Implement bulk job attributes for FlowProducer](https://github.com/appsignal/opentelemetry-instrumentation-bullmq/commit/0bad97a222bb34eefd29a69edff07f085bd5aa81)

Implement the `.bulk.names` and `.bulk.count` attributes for the
`FlowProducer.addBulk` method, like those in the `Queue.addBulk`
instrumentation.