### PR TITLE
Align with semantic conventions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@opentelemetry/api": "^1.3.0",
         "@opentelemetry/instrumentation": "^0.34.0",
-        "@opentelemetry/semantic-conventions": "^1.8.0",
+        "@opentelemetry/semantic-conventions": "^1.25.0",
         "flat": "^5.0.2"
       },
       "devDependencies": {
@@ -802,6 +802,15 @@
         "@opentelemetry/api": ">=1.0.0 <1.4.0"
       }
     },
+    "node_modules/@opentelemetry/core/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.8.0.tgz",
+      "integrity": "sha512-TYh1MRcm4JnvpqtqOwT9WYaBYY4KERHdToxs/suDTLviGRsQkIjS5yYROTYTSJQUnYLOn/TuOh5GoMwfLSU+Ew==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@opentelemetry/instrumentation": {
       "version": "0.34.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.34.0.tgz",
@@ -864,6 +873,15 @@
         "@opentelemetry/api": ">=1.0.0 <1.4.0"
       }
     },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.8.0.tgz",
+      "integrity": "sha512-TYh1MRcm4JnvpqtqOwT9WYaBYY4KERHdToxs/suDTLviGRsQkIjS5yYROTYTSJQUnYLOn/TuOh5GoMwfLSU+Ew==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@opentelemetry/sdk-trace-base": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.8.0.tgz",
@@ -879,6 +897,15 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": ">=1.0.0 <1.4.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.8.0.tgz",
+      "integrity": "sha512-TYh1MRcm4JnvpqtqOwT9WYaBYY4KERHdToxs/suDTLviGRsQkIjS5yYROTYTSJQUnYLOn/TuOh5GoMwfLSU+Ew==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@opentelemetry/sdk-trace-node": {
@@ -902,9 +929,9 @@
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.8.0.tgz",
-      "integrity": "sha512-TYh1MRcm4JnvpqtqOwT9WYaBYY4KERHdToxs/suDTLviGRsQkIjS5yYROTYTSJQUnYLOn/TuOh5GoMwfLSU+Ew==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.0.tgz",
+      "integrity": "sha512-M+kkXKRAIAiAP6qYyesfrC5TOmDpDVtsxuGfPcqd9B/iBrac+E14jYwrgm0yZBUIbIP2OnqC3j+UgkXLm1vxUQ==",
       "engines": {
         "node": ">=14"
       }
@@ -6004,6 +6031,14 @@
       "dev": true,
       "requires": {
         "@opentelemetry/semantic-conventions": "1.8.0"
+      },
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.8.0.tgz",
+          "integrity": "sha512-TYh1MRcm4JnvpqtqOwT9WYaBYY4KERHdToxs/suDTLviGRsQkIjS5yYROTYTSJQUnYLOn/TuOh5GoMwfLSU+Ew==",
+          "dev": true
+        }
       }
     },
     "@opentelemetry/instrumentation": {
@@ -6042,6 +6077,14 @@
       "requires": {
         "@opentelemetry/core": "1.8.0",
         "@opentelemetry/semantic-conventions": "1.8.0"
+      },
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.8.0.tgz",
+          "integrity": "sha512-TYh1MRcm4JnvpqtqOwT9WYaBYY4KERHdToxs/suDTLviGRsQkIjS5yYROTYTSJQUnYLOn/TuOh5GoMwfLSU+Ew==",
+          "dev": true
+        }
       }
     },
     "@opentelemetry/sdk-trace-base": {
@@ -6053,6 +6096,14 @@
         "@opentelemetry/core": "1.8.0",
         "@opentelemetry/resources": "1.8.0",
         "@opentelemetry/semantic-conventions": "1.8.0"
+      },
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.8.0.tgz",
+          "integrity": "sha512-TYh1MRcm4JnvpqtqOwT9WYaBYY4KERHdToxs/suDTLviGRsQkIjS5yYROTYTSJQUnYLOn/TuOh5GoMwfLSU+Ew==",
+          "dev": true
+        }
       }
     },
     "@opentelemetry/sdk-trace-node": {
@@ -6070,9 +6121,9 @@
       }
     },
     "@opentelemetry/semantic-conventions": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.8.0.tgz",
-      "integrity": "sha512-TYh1MRcm4JnvpqtqOwT9WYaBYY4KERHdToxs/suDTLviGRsQkIjS5yYROTYTSJQUnYLOn/TuOh5GoMwfLSU+Ew=="
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.0.tgz",
+      "integrity": "sha512-M+kkXKRAIAiAP6qYyesfrC5TOmDpDVtsxuGfPcqd9B/iBrac+E14jYwrgm0yZBUIbIP2OnqC3j+UgkXLm1vxUQ=="
     },
     "@sinonjs/commons": {
       "version": "1.8.3",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@opentelemetry/api": "^1.3.0",
     "@opentelemetry/instrumentation": "^0.34.0",
-    "@opentelemetry/semantic-conventions": "^1.8.0",
+    "@opentelemetry/semantic-conventions": "^1.25.0",
     "flat": "^5.0.2"
   },
   "peerDependencies": {

--- a/src/attributes.ts
+++ b/src/attributes.ts
@@ -1,3 +1,11 @@
+import {
+  SEMATTRS_MESSAGING_CONSUMER_ID,
+  SEMATTRS_MESSAGING_DESTINATION,
+  SEMATTRS_MESSAGING_MESSAGE_ID,
+  SEMATTRS_MESSAGING_OPERATION,
+  SEMATTRS_MESSAGING_SYSTEM,
+} from "@opentelemetry/semantic-conventions";
+
 const ns = "messaging.bullmq";
 const job = `${ns}.job`;
 const queue = `${ns}.queue`;
@@ -25,4 +33,12 @@ export const BullMQAttributes = {
   WORKER_RATE_LIMIT_MAX: `${worker}.rateLimiter.max`,
   WORKER_RATE_LIMIT_DURATION: `${worker}.rateLimiter.duration`,
   WORKER_RATE_LIMIT_GROUP: `${worker}.rateLimiter.groupKey`,
+};
+
+export const SemanticAttributes = {
+  MESSAGING_SYSTEM: SEMATTRS_MESSAGING_SYSTEM,
+  MESSAGING_DESTINATION: SEMATTRS_MESSAGING_DESTINATION,
+  MESSAGING_OPERATION: SEMATTRS_MESSAGING_OPERATION,
+  MESSAGING_MESSAGE_ID: SEMATTRS_MESSAGING_MESSAGE_ID,
+  MESSAGING_CONSUMER_ID: SEMATTRS_MESSAGING_CONSUMER_ID,
 };

--- a/src/attributes.ts
+++ b/src/attributes.ts
@@ -5,6 +5,7 @@ const worker = `${ns}.worker`;
 
 export const BullMQAttributes = {
   MESSAGING_SYSTEM: "bullmq",
+  MESSAGING_OPERATION_NAME: `${ns}.operation.name`,
   JOB_ATTEMPTS: `${job}.attempts`,
   JOB_DELAY: `${job}.delay`,
   JOB_FAILED_REASON: `${job}.failedReason`,
@@ -18,8 +19,6 @@ export const BullMQAttributes = {
   JOB_WAIT_CHILDREN_KEY: `${job}.parentOpts.waitChildrenKey`,
   JOB_BULK_NAMES: `${job}.bulk.names`,
   JOB_BULK_COUNT: `${job}.bulk.count`,
-  QUEUE_NAME: `${queue}.name`,
-  WORKER_NAME: `${worker}.name`,
   WORKER_CONCURRENCY: `${worker}.concurrency`,
   WORKER_LOCK_DURATION: `${worker}.lockDuration`,
   WORKER_LOCK_RENEW: `${worker}.lockRenewTime`,

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -151,7 +151,8 @@ export class BullMQInstrumentation extends InstrumentationBase {
   private _patchAddJob(): (original: Function) => (...args: any) => any {
     const instrumentation = this;
     const tracer = instrumentation.tracer;
-    const action = "Job.addJob";
+    const operationName = "Job.addJob";
+    const operationType = "create";
 
     return function addJob(original) {
       return async function patch(
@@ -189,9 +190,13 @@ export class BullMQInstrumentation extends InstrumentationBase {
         let childSpan: Span | undefined;
 
         if (shouldCreateSpan) {
-          const spanName = `${this.queueName}.${this.name} ${action}`;
+          const spanName = `${this.queueName} ${operationType}`;
           childSpan = tracer.startSpan(spanName, {
             kind: SpanKind.PRODUCER,
+            attributes: {
+              [SemanticAttributes.MESSAGING_OPERATION]: operationType,
+              [BullMQAttributes.MESSAGING_OPERATION_NAME]: operationName,
+            },
           });
         }
 
@@ -244,7 +249,8 @@ export class BullMQInstrumentation extends InstrumentationBase {
   private _patchQueueAdd(): (original: Function) => (...args: any) => any {
     const instrumentation = this;
     const tracer = instrumentation.tracer;
-    const action = "Queue.add";
+    const operationName = "Queue.add";
+    const operationType = "publish";
 
     return function add(original) {
       return async function patch(this: Queue, ...args: any): Promise<Job> {
@@ -257,9 +263,13 @@ export class BullMQInstrumentation extends InstrumentationBase {
 
         const [name] = [...args];
 
-        const spanName = `${this.name}.${name} ${action}`;
+        const spanName = `${this.name} ${operationType}`;
         const span = tracer.startSpan(spanName, {
           kind: SpanKind.PRODUCER,
+          attributes: {
+            [SemanticAttributes.MESSAGING_OPERATION]: operationType,
+            [BullMQAttributes.MESSAGING_OPERATION_NAME]: operationName,
+          },
         });
 
         return BullMQInstrumentation.withContext(this, original, span, args);
@@ -270,7 +280,8 @@ export class BullMQInstrumentation extends InstrumentationBase {
   private _patchQueueAddBulk(): (original: Function) => (...args: any) => any {
     const instrumentation = this;
     const tracer = instrumentation.tracer;
-    const action = "Queue.addBulk";
+    const operationName = "Queue.addBulk";
+    const operationType = "publish";
 
     return function addBulk(original) {
       return async function patch(
@@ -286,7 +297,7 @@ export class BullMQInstrumentation extends InstrumentationBase {
 
         const names = args[0].map((job) => job.name);
 
-        const spanName = `${this.name} ${action}`;
+        const spanName = `${this.name} ${operationType}`;
         const spanKind = instrumentation.shouldCreateSpan({
           isBulk: true,
           isFlow: false,
@@ -299,6 +310,8 @@ export class BullMQInstrumentation extends InstrumentationBase {
             [SemanticAttributes.MESSAGING_SYSTEM]:
               BullMQAttributes.MESSAGING_SYSTEM,
             [SemanticAttributes.MESSAGING_DESTINATION]: this.name,
+            [SemanticAttributes.MESSAGING_OPERATION]: operationType,
+            [BullMQAttributes.MESSAGING_OPERATION_NAME]: operationName,
             [BullMQAttributes.JOB_BULK_NAMES]: names,
             [BullMQAttributes.JOB_BULK_COUNT]: names.length,
           },
@@ -317,7 +330,8 @@ export class BullMQInstrumentation extends InstrumentationBase {
   ) => (...args: any) => any {
     const instrumentation = this;
     const tracer = instrumentation.tracer;
-    const action = "FlowProducer.add";
+    const operationName = "FlowProducer.add";
+    const operationType = "publish";
 
     return function add(original) {
       return async function patch(
@@ -332,7 +346,7 @@ export class BullMQInstrumentation extends InstrumentationBase {
           return await original.apply(this, [flow, opts]);
         }
 
-        const spanName = `${flow.queueName}.${flow.name} ${action}`;
+        const spanName = `${flow.queueName} ${operationType}`;
         const spanKind = instrumentation.shouldCreateSpan({
           isBulk: false,
           isFlow: true,
@@ -345,6 +359,8 @@ export class BullMQInstrumentation extends InstrumentationBase {
             [SemanticAttributes.MESSAGING_SYSTEM]:
               BullMQAttributes.MESSAGING_SYSTEM,
             [SemanticAttributes.MESSAGING_DESTINATION]: flow.queueName,
+            [SemanticAttributes.MESSAGING_OPERATION]: operationType,
+            [BullMQAttributes.MESSAGING_OPERATION_NAME]: operationName,
             [BullMQAttributes.JOB_NAME]: flow.name,
           },
           kind: spanKind,
@@ -368,7 +384,8 @@ export class BullMQInstrumentation extends InstrumentationBase {
   ) => (...args: any) => any {
     const instrumentation = this;
     const tracer = instrumentation.tracer;
-    const action = "FlowProducer.addBulk";
+    const operationName = "FlowProducer.addBulk";
+    const operationType = "publish";
 
     return function addBulk(original) {
       return async function patch(
@@ -382,7 +399,7 @@ export class BullMQInstrumentation extends InstrumentationBase {
           return await original.apply(this, args);
         }
 
-        const spanName = `${action}`;
+        const spanName = `(bulk) ${operationType}`;
         const spanKind = instrumentation.shouldCreateSpan({
           isBulk: true,
           isFlow: true,
@@ -395,6 +412,8 @@ export class BullMQInstrumentation extends InstrumentationBase {
           attributes: {
             [SemanticAttributes.MESSAGING_SYSTEM]:
               BullMQAttributes.MESSAGING_SYSTEM,
+            [SemanticAttributes.MESSAGING_OPERATION]: operationType,
+            [BullMQAttributes.MESSAGING_OPERATION_NAME]: operationName,
             [BullMQAttributes.JOB_BULK_NAMES]: names,
             [BullMQAttributes.JOB_BULK_COUNT]: names.length,
           },
@@ -414,6 +433,8 @@ export class BullMQInstrumentation extends InstrumentationBase {
   ) => (...args: any) => any {
     const instrumentation = this;
     const tracer = instrumentation.tracer;
+    const operationType = "process";
+    const operationName = "Worker.run";
 
     return function patch(original) {
       return async function callProcessJob(
@@ -425,14 +446,15 @@ export class BullMQInstrumentation extends InstrumentationBase {
         const currentContext = context.active();
         const producerContext = propagation.extract(currentContext, job.opts);
 
-        const spanName = `${job.queueName}.${job.name} Worker.${workerName} #${job.attemptsMade}`;
+        const spanName = `${job.queueName} ${operationType}`;
         const span = tracer.startSpan(spanName, {
           attributes: BullMQInstrumentation.dropInvalidAttributes({
             [SemanticAttributes.MESSAGING_SYSTEM]:
               BullMQAttributes.MESSAGING_SYSTEM,
             [SemanticAttributes.MESSAGING_CONSUMER_ID]: workerName,
             [SemanticAttributes.MESSAGING_MESSAGE_ID]: job.id,
-            [SemanticAttributes.MESSAGING_OPERATION]: "receive",
+            [SemanticAttributes.MESSAGING_OPERATION]: operationType,
+            [BullMQAttributes.MESSAGING_OPERATION_NAME]: operationName,
             [BullMQAttributes.JOB_NAME]: job.name,
             [BullMQAttributes.JOB_ATTEMPTS]: job.attemptsMade,
             [BullMQAttributes.JOB_TIMESTAMP]: job.timestamp,
@@ -442,8 +464,7 @@ export class BullMQInstrumentation extends InstrumentationBase {
               BullMQAttributes.JOB_OPTS,
               job.opts,
             ),
-            [BullMQAttributes.QUEUE_NAME]: job.queueName,
-            [BullMQAttributes.WORKER_NAME]: workerName,
+            [SemanticAttributes.MESSAGING_DESTINATION]: job.queueName,
             [BullMQAttributes.WORKER_CONCURRENCY]: this.opts?.concurrency,
             [BullMQAttributes.WORKER_LOCK_DURATION]: this.opts?.lockDuration,
             [BullMQAttributes.WORKER_LOCK_RENEW]: this.opts?.lockRenewTime,

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -3,7 +3,6 @@ import {
   InstrumentationConfig,
   InstrumentationNodeModuleDefinition,
 } from "@opentelemetry/instrumentation";
-import { SemanticAttributes } from "@opentelemetry/semantic-conventions";
 import type { Attributes, Link, Span } from "@opentelemetry/api";
 import {
   context,
@@ -27,7 +26,7 @@ import type {
 import { flatten } from "flat";
 
 import { VERSION } from "./version";
-import { BullMQAttributes } from "./attributes";
+import { SemanticAttributes, BullMQAttributes } from "./attributes";
 
 declare type Fn = (...args: any[]) => any;
 const BULK_CONTEXT = Symbol("BULLMQ_BULK_CONTEXT");

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -227,7 +227,7 @@ export class BullMQInstrumentation extends InstrumentationBase {
             if (shouldSetAttributes) {
               span.setAttributes(
                 BullMQInstrumentation.dropInvalidAttributes({
-                  [SemanticAttributes.MESSAGE_ID]: this.id,
+                  [SemanticAttributes.MESSAGING_MESSAGE_ID]: this.id,
                   [BullMQAttributes.JOB_TIMESTAMP]: this.timestamp,
                 }),
               );

--- a/test/instrumentation.test.ts
+++ b/test/instrumentation.test.ts
@@ -140,7 +140,6 @@ describe("bullmq", () => {
   beforeEach(() => {
     contextManager.enable();
     context.setGlobalContextManager(contextManager);
-    trace.setGlobalTracerProvider(provider);
     instrumentation.setTracerProvider(provider);
     trace.setGlobalTracerProvider(provider);
     instrumentation.setConfig(defaultConfig);

--- a/test/instrumentation.test.ts
+++ b/test/instrumentation.test.ts
@@ -257,7 +257,7 @@ describe("bullmq", () => {
 
       // TODO: why is there no message ID?
       assertDoesNotContain(queueAddSpan?.attributes!, [
-        "message.id",
+        "messaging.message_id",
         "messaging.bullmq.job.parentOpts.parentKey",
         "messaging.bullmq.job.parentOpts.flowChildrenKey",
       ]);
@@ -276,7 +276,7 @@ describe("bullmq", () => {
       assert.notStrictEqual(queueAddSpan, undefined);
       assertContains(queueAddSpan?.attributes!, {
         "messaging.bullmq.job.name": "jobName",
-        "message.id": "foobar",
+        "messaging.message_id": "foobar",
       });
     });
 
@@ -469,9 +469,9 @@ describe("bullmq", () => {
         "messaging.destination": "queueName",
         "messaging.bullmq.job.name": "jobName",
       });
-      // TODO: rename to `messaging.message.id`
+
       assert.strictEqual(
-        typeof jobAddSpan?.attributes!["message.id"],
+        typeof jobAddSpan?.attributes!["messaging.message_id"],
         "string",
       );
       assertDoesNotContain(jobAddSpan?.attributes!, [
@@ -526,14 +526,14 @@ describe("bullmq", () => {
           "bull:queueName:waiting-children",
       });
       assert.strictEqual(
-        typeof jobAddSpan?.attributes!["message.id"],
+        typeof jobAddSpan?.attributes!["messaging.message_id"],
         "string",
       );
       assertDoesNotContain(jobAddSpan?.attributes!, [
         "messaging.bullmq.job.parentOpts.parentKey",
       ]);
 
-      const jobId = jobAddSpan?.attributes!["message.id"] as string;
+      const jobId = jobAddSpan?.attributes!["messaging.message_id"] as string;
 
       const childJobAddSpan = spans.find(
         (span) => span.name === "childQueueName.childJobName Job.addJob",
@@ -550,14 +550,14 @@ describe("bullmq", () => {
         "messaging.bullmq.job.parentOpts.parentKey": `bull:queueName:${jobId}`,
       });
       assert.strictEqual(
-        typeof childJobAddSpan?.attributes!["message.id"],
+        typeof childJobAddSpan?.attributes!["messaging.message_id"],
         "string",
       );
       assert.notStrictEqual(
-        childJobAddSpan?.attributes!["message.id"],
+        childJobAddSpan?.attributes!["messaging.message_id"],
         "unknown",
       );
-      assert.notStrictEqual(childJobAddSpan?.attributes!["message.id"], jobId);
+      assert.notStrictEqual(childJobAddSpan?.attributes!["messaging.message_id"], jobId);
       assertDoesNotContain(childJobAddSpan?.attributes!, [
         "messaging.bullmq.job.parentOpts.waitChildrenKey",
       ]);


### PR DESCRIPTION
### Main changes

- Use `messaging.message_id` instead of `message.id`.
- Use `process`, not `receive`, for the `messaging.operation` value
in the `Worker.run` span.
- Remove `messaging.bullmq.(worker|queue).name` attributes. The name
of the worker is the name of the queue, which is represented in the
`messaging.destination` attributes.
- Use a `messaging.bullmq.operation.name` to provide BullMQ-meaningful
names of operations. This mirrors the `messaging.operation.name`
attribute in the not-yet-published v1.26.0 of the OpenTelemetry
Semantic Conventions.
- Name spans by the destination (the queue) and the operation type.
Notably, this removes the job name, which per BullMQ's documentation,
is meant to be human-meaningful and uniquely identify the job, meaning
it's very likely to be high-cardinality.

### Notes

When implementing this, I have stuck to the [v1.25.0 documentation for semantic attributes](https://github.com/lmolkova/semantic-conventions/blob/release/v1.25.x/docs/messaging/messaging-spans.md), with the added limitation of only using those attributes which are implemented by the `@opentelemetry/semantic-conventions@1.25.0` package.

When reviewing this, note that [the currently published documentation in the OpenTelemetry website](https://opentelemetry.io/docs/specs/semconv/messaging/messaging-spans/) is for the not-yet-released v1.26.0 semantic attributes. I have borrowed ideas from it (most notably `messaging.bullmq.operation.name`, which would be named `messaging.operation.name` in v1.26.0) but I am intentionally sticking to complying with v1.25.0.