### PR TITLE
Add flag to use producer context as consumer parent

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,12 @@ registerInstrumentations({
 
 ## Configuration options
 
-| Name                          | Type      | Default&nbsp;value | Description                                                                                                                                                                                                  |
-| ----------------------------- | --------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `emitCreateSpansForBulk`      | `boolean` | `true`             | Whether to emit a create span for each individual job enqueued by `Queue.addBulk` or `FlowProducer.addBulk`. The span representing the overall bulk operation is emitted regardless.                         |
-| `emitCreateSpansForFlow`      | `boolean` | `true`             | Whether to emit a create span for each individual job enqueued by `FlowProducer.add` or `FlowProducer.addBulk`. The span representing the overall flow operation is emitted regardless.                      |
-| `requireParentSpanForPublish` | `boolean` | `false`            | Whether to omit emitting a publish span (and the create child spans for it, for bulk and flow operations) when there is no parent span, meaning that the span created would be the root span of a new trace. |
+| Name                                  | Type      | Default&nbsp;value | Description                                                                                                                                                                                                  |
+|---------------------------------------| --------- | ------------------ |--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `emitCreateSpansForBulk`              | `boolean` | `true`             | Whether to emit a create span for each individual job enqueued by `Queue.addBulk` or `FlowProducer.addBulk`. The span representing the overall bulk operation is emitted regardless.                         |
+| `emitCreateSpansForFlow`              | `boolean` | `true`             | Whether to emit a create span for each individual job enqueued by `FlowProducer.add` or `FlowProducer.addBulk`. The span representing the overall flow operation is emitted regardless.                      |
+| `requireParentSpanForPublish`         | `boolean` | `false`            | Whether to omit emitting a publish span (and the create child spans for it, for bulk and flow operations) when there is no parent span, meaning that the span created would be the root span of a new trace. |
+| `useProducerContextAsConsumerParent`  | `boolean` | `false`            | Whether to use the producer context as the parent for the consumer span. Consumer and Producer will share the same TraceId in this case.                                                                     |
 
 ## Emitted spans
 

--- a/README.md
+++ b/README.md
@@ -46,12 +46,12 @@ registerInstrumentations({
 
 ## Configuration options
 
-| Name                                  | Type      | Default&nbsp;value | Description                                                                                                                                                                                                  |
-|---------------------------------------| --------- | ------------------ |--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `emitCreateSpansForBulk`              | `boolean` | `true`             | Whether to emit a create span for each individual job enqueued by `Queue.addBulk` or `FlowProducer.addBulk`. The span representing the overall bulk operation is emitted regardless.                         |
-| `emitCreateSpansForFlow`              | `boolean` | `true`             | Whether to emit a create span for each individual job enqueued by `FlowProducer.add` or `FlowProducer.addBulk`. The span representing the overall flow operation is emitted regardless.                      |
-| `requireParentSpanForPublish`         | `boolean` | `false`            | Whether to omit emitting a publish span (and the create child spans for it, for bulk and flow operations) when there is no parent span, meaning that the span created would be the root span of a new trace. |
-| `useProducerContextAsConsumerParent`  | `boolean` | `false`            | Whether to use the producer context as the parent for the consumer span. Consumer and Producer will share the same TraceId in this case.                                                                     |
+| Name                                 | Type      | Default&nbsp;value | Description                                                                                                                                                                                                  |
+| ------------------------------------ | --------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `emitCreateSpansForBulk`             | `boolean` | `true`             | Whether to emit a create span for each individual job enqueued by `Queue.addBulk` or `FlowProducer.addBulk`. The span representing the overall bulk operation is emitted regardless.                         |
+| `emitCreateSpansForFlow`             | `boolean` | `true`             | Whether to emit a create span for each individual job enqueued by `FlowProducer.add` or `FlowProducer.addBulk`. The span representing the overall flow operation is emitted regardless.                      |
+| `requireParentSpanForPublish`        | `boolean` | `false`            | Whether to omit emitting a publish span (and the create child spans for it, for bulk and flow operations) when there is no parent span, meaning that the span created would be the root span of a new trace. |
+| `useProducerContextAsConsumerParent` | `boolean` | `false`            | Whether to use the producer context as the parent for the consumer span. Consumer and Producer will share the same TraceId in this case.                                                                     |
 
 ## Emitted spans
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@appsignal/opentelemetry-instrumentation-bullmq",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@appsignal/opentelemetry-instrumentation-bullmq",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0",
@@ -6099,7 +6099,8 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-1.8.0.tgz",
       "integrity": "sha512-ueLmocbWDi1aoU4IPdOQyt4qz/Dx+NYyU4qoa3d683usbnkDLUXYXJFfKIMPFV2BbrI5qtnpTtzErCKewoM8aw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@opentelemetry/core": {
       "version": "1.8.0",
@@ -6444,13 +6445,15 @@
     "acorn-import-attributes": {
       "version": "1.9.5",
       "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
-      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ=="
+      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
+      "requires": {}
     },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "8.2.0",
@@ -7347,7 +7350,8 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
       "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-scope": {
       "version": "7.1.1",
@@ -7508,7 +7512,8 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/fengari-interop/-/fengari-interop-0.1.3.tgz",
       "integrity": "sha512-EtZ+oTu3kEwVJnoymFPBVLIbQcCoy9uWCVnMA6h3M/RqHkUBsLYp29+RRHf9rKr6GwjubWREU1O7RretFIXjHw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "file-entry-cache": {
       "version": "6.0.1",

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -50,12 +50,18 @@ export interface BullMQInstrumentationConfig extends InstrumentationConfig {
   /** Require a parent span in order to create a producer span
    * (a span for the enqueueing of one or more jobs) -- defaults to `false` */
   requireParentSpanForPublish?: boolean;
+
+  /** Whether to use the producer context as the parent for the consumer span.
+   * Consumer and Producer will share the same TraceId in this case. Must not be
+   * used for batch message processing. Defaults to `false` */
+  useProducerContextAsConsumerParent?: boolean;
 }
 
 export const defaultConfig: Required<BullMQInstrumentationConfig> = {
   emitCreateSpansForBulk: true,
   emitCreateSpansForFlow: true,
   requireParentSpanForPublish: false,
+  useProducerContextAsConsumerParent: false,
   // unused by `configFor` but required for the type
   enabled: true,
 };
@@ -446,42 +452,52 @@ export class BullMQInstrumentation extends InstrumentationBase {
         const producerContext = propagation.extract(currentContext, job.opts);
 
         const spanName = `${job.queueName} ${operationType}`;
-        const span = tracer.startSpan(spanName, {
-          attributes: BullMQInstrumentation.dropInvalidAttributes({
-            [SemanticAttributes.MESSAGING_SYSTEM]:
-              BullMQAttributes.MESSAGING_SYSTEM,
-            [SemanticAttributes.MESSAGING_CONSUMER_ID]: workerName,
-            [SemanticAttributes.MESSAGING_MESSAGE_ID]: job.id,
-            [SemanticAttributes.MESSAGING_OPERATION]: operationType,
-            [BullMQAttributes.MESSAGING_OPERATION_NAME]: operationName,
-            [BullMQAttributes.JOB_NAME]: job.name,
-            [BullMQAttributes.JOB_ATTEMPTS]: job.attemptsMade,
-            [BullMQAttributes.JOB_TIMESTAMP]: job.timestamp,
-            [BullMQAttributes.JOB_DELAY]: job.delay,
-            [BullMQAttributes.JOB_REPEAT_KEY]: job.repeatJobKey,
-            ...BullMQInstrumentation.attrMap(
-              BullMQAttributes.JOB_OPTS,
-              job.opts,
+        const span = tracer.startSpan(
+          spanName,
+          {
+            attributes: BullMQInstrumentation.dropInvalidAttributes({
+              [SemanticAttributes.MESSAGING_SYSTEM]:
+                BullMQAttributes.MESSAGING_SYSTEM,
+              [SemanticAttributes.MESSAGING_CONSUMER_ID]: workerName,
+              [SemanticAttributes.MESSAGING_MESSAGE_ID]: job.id,
+              [SemanticAttributes.MESSAGING_OPERATION]: operationType,
+              [BullMQAttributes.MESSAGING_OPERATION_NAME]: operationName,
+              [BullMQAttributes.JOB_NAME]: job.name,
+              [BullMQAttributes.JOB_ATTEMPTS]: job.attemptsMade,
+              [BullMQAttributes.JOB_TIMESTAMP]: job.timestamp,
+              [BullMQAttributes.JOB_DELAY]: job.delay,
+              [BullMQAttributes.JOB_REPEAT_KEY]: job.repeatJobKey,
+              ...BullMQInstrumentation.attrMap(
+                BullMQAttributes.JOB_OPTS,
+                job.opts,
+              ),
+              [SemanticAttributes.MESSAGING_DESTINATION]: job.queueName,
+              [BullMQAttributes.WORKER_CONCURRENCY]: this.opts?.concurrency,
+              [BullMQAttributes.WORKER_LOCK_DURATION]: this.opts?.lockDuration,
+              [BullMQAttributes.WORKER_LOCK_RENEW]: this.opts?.lockRenewTime,
+              [BullMQAttributes.WORKER_RATE_LIMIT_MAX]: this.opts?.limiter?.max,
+              [BullMQAttributes.WORKER_RATE_LIMIT_DURATION]:
+                this.opts?.limiter?.duration,
+              // Limit by group keys was removed in bullmq 3.x
+              [BullMQAttributes.WORKER_RATE_LIMIT_GROUP]: (
+                this.opts?.limiter as any
+              )?.groupKey,
+            }),
+            kind: SpanKind.CONSUMER,
+            links: BullMQInstrumentation.dropInvalidLinks(
+              instrumentation.configFor("useProducerContextAsConsumerParent")
+                ? []
+                : [
+                    {
+                      context: trace.getSpanContext(producerContext),
+                    },
+                  ],
             ),
-            [SemanticAttributes.MESSAGING_DESTINATION]: job.queueName,
-            [BullMQAttributes.WORKER_CONCURRENCY]: this.opts?.concurrency,
-            [BullMQAttributes.WORKER_LOCK_DURATION]: this.opts?.lockDuration,
-            [BullMQAttributes.WORKER_LOCK_RENEW]: this.opts?.lockRenewTime,
-            [BullMQAttributes.WORKER_RATE_LIMIT_MAX]: this.opts?.limiter?.max,
-            [BullMQAttributes.WORKER_RATE_LIMIT_DURATION]:
-              this.opts?.limiter?.duration,
-            // Limit by group keys was removed in bullmq 3.x
-            [BullMQAttributes.WORKER_RATE_LIMIT_GROUP]: (
-              this.opts?.limiter as any
-            )?.groupKey,
-          }),
-          kind: SpanKind.CONSUMER,
-          links: BullMQInstrumentation.dropInvalidLinks([
-            {
-              context: trace.getSpanContext(producerContext),
-            },
-          ]),
-        });
+          },
+          instrumentation.configFor("useProducerContextAsConsumerParent")
+            ? producerContext
+            : currentContext,
+        );
 
         const consumerContext = trace.setSpan(currentContext, span);
 

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -52,8 +52,7 @@ export interface BullMQInstrumentationConfig extends InstrumentationConfig {
   requireParentSpanForPublish?: boolean;
 
   /** Whether to use the producer context as the parent for the consumer span.
-   * Consumer and Producer will share the same TraceId in this case. Must not be
-   * used for batch message processing. Defaults to `false` */
+   * Consumer and Producer will share the same TraceId in this case. Defaults to `false` */
   useProducerContextAsConsumerParent?: boolean;
 }
 


### PR DESCRIPTION
## Issue

Fixes #10 

## What

Adds a new `useProducerContextAsConsumerParent` that defaults to false. When set to true, the consumer trace uses the context of the producer as its active context, i.e. it keeps the same traceId. In that case, there is no link to the producer span.